### PR TITLE
Update prune to also check against granted_sso_start_url

### DIFF
--- a/awscfg.go
+++ b/awscfg.go
@@ -87,7 +87,7 @@ func Merge(opts MergeOpts) error {
 	if opts.Prune {
 		// remove any config sections that have 'common_fate_generated_from' as a key
 		for _, sec := range opts.Config.Sections() {
-			if sec.HasKey("common_fate_generated_from") {
+			if sec.HasKey("common_fate_generated_from") && sec.Key("granted_sso_start_url").String() == opts.Profiles[0].SSOStartURL {
 				opts.Config.DeleteSection(sec.Name())
 			}
 		}


### PR DESCRIPTION
Prune in its current form just compares against the existence of common_fate_generated_from, this can be problematic if the user has generated aws profiles with granted from multiple aws organizations since prune will blow away all entries, not just entries for the aws org the user is trying to prune/populate.

This fix attempts to solve that problem by checking the SSOStartURL of the populated entries and only pruning entries that match the SSOStartURL of the current run. Since the SSOStartURL will be the same for all Profiles in a populate run, I'm just using index zero to do the match. I'm open to suggestions on a cleaner way to implement this fix as well.